### PR TITLE
Add VMM with on-demand paging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "kernel/lib/3rdparty/cxxshim"]
 	path = kernel/lib/3rdparty/cxxshim
 	url = https://github.com/managarm/cxxshim
+[submodule "kernel/lib/davSTL"]
+	path = kernel/lib/davSTL
+	url = git@github.com:davidtranhq/davSTL

--- a/kernel/include/kernel/Allocator.h
+++ b/kernel/include/kernel/Allocator.h
@@ -1,0 +1,41 @@
+#ifndef DAVOS_KERNEL_ALLOCATOR_H_INCLUDED
+#define DAVOS_KERNEL_ALLOCATOR_H_INCLUDED
+
+#include <cstddef>
+
+using std::size_t;
+
+/**
+ * @brief CRTP base class for an allocator of type T.
+ * 
+ * @tparam Derived The derived class implementation.
+ * @tparam T The type allocated by this allocator.
+ */
+template <typename Derived>
+class Allocator;
+
+template <template <typename> class Derived, typename T>
+class Allocator<Derived<T>> {
+public:
+    using value_type = T;
+
+    auto allocate(size_t size) -> T * {
+        return static_cast<Derived<T> *>(this)->allocate_impl(size);
+    }
+
+    auto deallocate(T *ptr, size_t size = 0) -> void {
+        static_cast<Derived<T> *>(this)->deallocate_impl(ptr, size);
+    }
+
+    /**
+     * @brief Add memory to be managed by the allocator. 
+     * 
+     * @param ptr 
+     * @param size 
+     */
+    auto add_memory(T *ptr, size_t size) -> void {
+        static_cast<Derived<T> *>(this)->add_memory_impl(ptr, size);
+    }
+};
+
+#endif

--- a/kernel/include/kernel/FreeListAllocator.h
+++ b/kernel/include/kernel/FreeListAllocator.h
@@ -1,0 +1,31 @@
+#ifndef DAVOS_KERNEL_FREE_LIST_ALLOCATOR_H_INCLUDED
+#define DAVOS_KERNEL_FREE_LIST_ALLOCATOR_H_INCLUDED
+
+#include <cstddef>
+#include <kernel/Allocator.h>
+#include <kernel/kernel.h>
+
+template <typename T>
+class FreeListAllocator : public Allocator<FreeListAllocator<T>>
+{
+public:
+    FreeListAllocator() = default;
+
+    // FreeListAllocator(T *base, std::size_t size);
+    
+    auto allocate_impl(std::size_t request) -> T *;
+    
+    auto deallocate_impl(T *base, std::size_t size) -> void;
+
+    auto add_memory_impl(T *base, std::size_t size) -> void;
+
+// private:
+    struct FreeBlockHeader;
+    struct UsedBlockHeader;
+
+    FreeBlockHeader *head = nullptr;
+};
+
+#include <kernel/FreeListAllocator.tpp> 
+
+#endif // DAVOS_KERNEL_FREE_LIST_ALLOCATOR_H_INCLUDED

--- a/kernel/include/kernel/FreeListAllocator.tpp
+++ b/kernel/include/kernel/FreeListAllocator.tpp
@@ -1,0 +1,155 @@
+#include <kernel/FreeListAllocator.h>
+#include <kernel/macros.h>
+#include <cstdint>
+#include <new>
+
+// template <typename T>
+// FreeListAllocator<T>::FreeListAllocator(T *base, size_t size)
+//     : head(new(base) FreeBlockHeader {size})
+// {}
+
+template <typename T>
+auto FreeListAllocator<T>::allocate_impl(size_t request) -> T * {
+    // First fit
+    auto curr = head;
+    while (curr && !curr->can_fit(request)) {
+        curr = curr->next;
+    }
+    if (!curr) {
+        kernel_panic("ran out of virtual memory!\n");
+    }
+    auto allocated = static_cast<void *>(nullptr);
+    if (curr->perfect_fit(request)) {
+        allocated = curr->reserve_entire(request);
+        if (curr == head) {
+            head = curr->next;
+        }
+    } else {
+        allocated = curr->reserve_end(request);
+    }
+
+#ifdef DEBUG_BUILD_FREE_LIST_ALLOCATOR
+    DEBUG("allocate: %x\n", request);
+    head->print_free_list();
+#endif
+
+    return reinterpret_cast<T *>
+        (reinterpret_cast<UsedBlockHeader *>(allocated) + 1);
+}
+
+template <typename T>
+auto FreeListAllocator<T>::deallocate_impl(T *base, size_t size) -> void {
+    auto curr = head;
+    auto prev = static_cast<FreeBlockHeader *>(nullptr);
+    auto used_block = reinterpret_cast<FreeListAllocator<T>::UsedBlockHeader *>(base) - 1;
+    if (used_block->magic != UsedBlockHeader::magic_constant) {
+        kernel_panic("invalid memory free\n");
+    }
+    while (curr && reinterpret_cast<uintptr_t>(curr) < reinterpret_cast<uintptr_t>(used_block)) {
+        prev = curr;
+        curr = curr->next;
+    }
+    auto freed = new(used_block) FreeBlockHeader
+        {used_block->size + sizeof(UsedBlockHeader) - sizeof(FreeBlockHeader), curr, prev};
+    
+    
+    if (!prev) {
+        head = freed;
+    } else {
+        prev->next = freed;
+    }
+    if (curr) {
+        curr->prev = freed;
+    }
+
+    freed->coalesce_next();
+    freed->coalesce_prev();
+
+#ifdef DEBUG_BUILD_FREE_LIST_ALLOCATOR
+    DEBUG("deallocate: %p, %x\n", base, size);
+    head->print_free_list();
+#endif
+}
+
+template <typename T>
+auto FreeListAllocator<T>::add_memory_impl(T *base, size_t size) -> void {
+    DEBUG("head: %x\n", head);
+    DEBUG("adding memory: %x\n", size);
+    auto allocated = new(base) UsedBlockHeader {size};
+    allocated += 1;
+    deallocate_impl(reinterpret_cast<T *>(allocated), 0);
+}
+
+template <typename T>
+struct FreeListAllocator<T>::FreeBlockHeader {
+    size_t size {};
+    FreeBlockHeader* next = nullptr;
+    FreeBlockHeader* prev = nullptr;
+
+    auto can_fit(size_t request) -> bool const {
+        return request + sizeof(UsedBlockHeader) <= size;
+    }
+
+    auto perfect_fit(size_t request) -> bool const {
+        return request + sizeof(UsedBlockHeader) == size;
+    }
+
+    auto real_size() -> size_t const {
+        return size + sizeof(FreeBlockHeader);
+    }
+
+    auto unlink() -> void {
+        if (prev) prev->next = next;
+        if (next) next->prev = prev;
+    }
+
+    auto reserve_end(size_t request) -> UsedBlockHeader * {
+        auto allocation_size = request + sizeof(UsedBlockHeader);
+        auto free_block_end = reinterpret_cast<uintptr_t>(this) + sizeof(FreeBlockHeader) + size;
+        auto allocation_address = reinterpret_cast<void *>(free_block_end - allocation_size);
+        auto allocated = new(allocation_address) UsedBlockHeader{request};
+        size -= allocation_size;
+        return allocated;
+    }
+
+    auto reserve_entire(size_t request) -> UsedBlockHeader * {
+        unlink();
+        auto allocated = new(this) UsedBlockHeader{request};
+        return allocated;
+    }
+
+    auto coalesce_next() -> void {
+        if (next && reinterpret_cast<uintptr_t>(next)
+                    == reinterpret_cast<uintptr_t>(this) + real_size()) {
+            size += next->real_size();
+            next = next->next;
+        }
+    }
+
+    auto coalesce_prev() -> void {
+        if (prev && reinterpret_cast<uintptr_t>(this) 
+                    == reinterpret_cast<uintptr_t>(prev) + prev->real_size()) {
+            prev->size += real_size();
+            prev->next = next;
+        }
+    }
+
+#ifdef DEBUG_BUILD_FREE_LIST_ALLOCATOR
+    auto print_free_list() -> void {
+        DEBUG("\n====FREE LIST======\n");
+        auto curr = this;
+        while (curr) {
+            DEBUG("%p: {size: %x, next: %p, prev: %p}\n", curr, curr->size, curr->next, curr->prev);
+            curr = curr->next;
+        }
+    }
+#endif
+};
+
+template <typename T>
+struct FreeListAllocator<T>::UsedBlockHeader {
+    static constexpr uint64_t magic_constant = 0x11223344aabbccdd;
+
+    size_t size {};
+    uint64_t magic {magic_constant};
+};

--- a/kernel/include/kernel/PageTreeNode.h
+++ b/kernel/include/kernel/PageTreeNode.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#include <kernel/vmm.h>
+#include <kernel/paging.h>
 
 class PageTreeNode
 {

--- a/kernel/include/kernel/VirtualMemoryAllocator.h
+++ b/kernel/include/kernel/VirtualMemoryAllocator.h
@@ -1,0 +1,51 @@
+#ifndef DAVOS_KERNEL_BUDDY_ALLOCATOR_H_INCLUDED
+#define DAVOS_KERNEL_BUDDY_ALLOCATOR_H_INCLUDED
+
+#include <stdint.h>
+
+class VirtualMemoryAllocator
+{
+public:
+    /**
+     * @brief Construct a new Buddy Allocator with available memory space
+     * starting at the given address and with the given size.
+     * 
+     * @param start_address 
+     * @param size 
+     */
+    VirtualMemoryAllocator(void *start_address, uint64_t size);
+
+    /**
+     * @brief Allocate a contiguous block of memory at least as big as the given size.
+     * 
+     * @param size 
+     * @return void* 
+     */
+    auto allocate(uint64_t size) -> void *;
+
+    /**
+     * @brief Deallocate a block of memory. 
+     * 
+     * @param ptr 
+     */
+    auto deallocate(void *ptr) -> void;
+
+private:
+    struct FreeBlock
+    {
+        FreeBlock *next = nullptr;
+        void *address = nullptr;
+        uint8_t order = 0;
+    };
+
+    struct FreeBlockList 
+    {
+        FreeBlock *head = nullptr;
+        uint64_t *used_bitmap = nullptr;
+    };
+
+    constexpr static uint8_t max_order = 11;
+    FreeBlockList free_block_lists[max_order] = {};
+};
+
+#endif

--- a/kernel/include/kernel/constants.h
+++ b/kernel/include/kernel/constants.h
@@ -1,0 +1,9 @@
+#ifndef DAVOS_KERNEL_CONSTANTS
+#define DAVOS_KERNEL_CONSTANTS
+
+#include <cstddef>
+
+constexpr auto page_size = std::size_t {0x1000};
+constexpr auto frame_size = std::size_t {0x1000};
+
+#endif

--- a/kernel/include/kernel/frame_allocator.h
+++ b/kernel/include/kernel/frame_allocator.h
@@ -3,39 +3,44 @@
 
 #include <stdint.h>
 
-void frame_allocator_init();
+auto frame_allocator_init() -> void;
 
 /**
  * @brief Get a new physical frame. Returns the physical address of the new frame.
  */
-void *allocate_frame();
+auto allocate_frame() -> void *;
 
 /**
  * @brief Frees a previously allocated physical frame. Do not deallocate the same frame twice
  * (the function does not check for this).
  */
-void deallocate_frame(void *frame_to_deallocate);
+auto deallocate_frame(void *frame_to_deallocate) -> void;
 
 /**
  * @brief Get the number of available frames left. 
  */
-uint64_t available_frames();
+auto available_frames() -> uint64_t;
 
 /**
  * @brief Get a pointer pointing to the corresponding virtual address of a physical address.
  */
-void *kernel_physical_to_virtual(void *physical_address);
+auto kernel_physical_to_virtual(void *physical_address) -> void *;
 
 /**
  * @brief Get the virtual address of the given physical kernel address.
  */
-uintptr_t kernel_physical_to_virtual(uintptr_t physical_address);
+auto kernel_physical_to_virtual(uintptr_t physical_address) -> uintptr_t;
 
 /**
  * @brief Reclaim bootloader-reclaimable memory allocated by Limine.
  * (This is safe to do once we've set up our own page tables, since Limine
  * uses bootloader-reclaimable memory for the Limine page tables.
  */
-void free_limine_bootloader_memory();
+auto free_limine_bootloader_memory() -> void;
+
+/**
+ * @brief Print the base, limit, and mapping type of each of the initial Limine memory map
+ */
+auto print_memory_map() -> void;
 
 #endif

--- a/kernel/include/kernel/paging.h
+++ b/kernel/include/kernel/paging.h
@@ -1,0 +1,69 @@
+/**
+ * @file paging.h
+ * @brief Interface for the virtual memory manager
+ */
+
+#ifndef DAVOS_KERNEL_PAGING_H_INCLUDED
+#define DAVOS_KERNEL_PAGING_H_INCLUDED
+
+#include <stdint.h>
+#include <frg/array.hpp>
+
+/**
+ * @brief Permission, access and cache policy flags for virtual-to-physical mappings.
+ */
+enum PageFlags : uint64_t
+{
+    None = 0,
+    Present = 1ULL,
+    Write = 1ULL << 1,        // allow writes
+    User = 1ULL << 2,         // allow user-mode access
+    WriteThrough = 1ULL << 3, // use write-through caching policy
+    CacheDisable = 1ULL << 4,
+    ExecuteDisable = 1ULL << 63, // disable instruction fetches
+};
+
+struct MemoryRegion {
+    uintptr_t base {};
+    size_t size {};
+};
+
+constexpr uint16_t paging_num_free_memory_regions = 16;
+
+/**
+ * @brief Allocate space for the new page table, and re-map essential mappings
+ * mapped by Limine. Then free the old page table by reclaiming bootloader reclaimable
+ * memory.
+ */
+void paging_init();
+
+/**
+ * @brief Add a virtual to physical mapping to the tree.
+ * Physical base should point to a contiguous region in physical memory of length
+ * `length` whose frames have already been allocated.
+ *
+ * @param virtual_base
+ * @param physical_base
+ * @param length
+ * @param flags permission and cache policy flags
+ */
+void paging_add_mapping(uintptr_t virtual_base,
+                     uintptr_t physical_base,
+                     uint64_t length,
+                     PageFlags flags);
+
+/**
+ * @brief Allocate (not-necessarily contiguous) physical memory
+ * for the specified contiguous virtual address region and map it in the page tree.
+ */
+auto paging_allocate_and_map(uintptr_t virtual_base, size_t length, PageFlags flags) -> void;
+
+/**
+ * @brief Get the virtual memory regions that are free to be managed (e.g. by an allocator)
+ * after the initial reserved page mappings have been set up.
+ * 
+ * @return frg::array<MemoryRegion> 
+ */
+auto paging_get_initial_free_regions() -> frg::array<MemoryRegion, paging_num_free_memory_regions>;
+
+#endif

--- a/kernel/include/kernel/tests.h
+++ b/kernel/include/kernel/tests.h
@@ -13,4 +13,6 @@ void test_stack_overflow();
 
 void test_paging();
 
+void test_free_list_allocator();
+
 #endif

--- a/kernel/include/kernel/vmm.h
+++ b/kernel/include/kernel/vmm.h
@@ -44,5 +44,4 @@ void vmm_add_mapping(uintptr_t virtual_base,
                      uint64_t length,
                      PageFlags flags);
 
-uintptr_t vmm_virtual_to_physical(uintptr_t virtual_address);
 #endif

--- a/kernel/include/kernel/vmm.h
+++ b/kernel/include/kernel/vmm.h
@@ -1,47 +1,17 @@
-/**
- * @file vmm.h
- * @brief Interface for the virtual memory manager
- */
-
 #ifndef DAVOS_KERNEL_VMM_H_INCLUDED
 #define DAVOS_KERNEL_VMM_H_INCLUDED
 
-#include <stdint.h>
+#include <kernel/Allocator.h>
+
+auto vmm_init() -> void;
+
+auto add_virtual_memory(void *base, size_t size) -> void;
 
 /**
- * @brief Permission, access and cache policy flags for virtual-to-physical mappings.
+ * @brief Allocate a contiguous region of virtual address space.
  */
-enum PageFlags : uint64_t
-{
-    None = 0,
-    Present = 1ULL,
-    Write = 1ULL << 1,        // allow writes
-    User = 1ULL << 2,         // allow user-mode access
-    WriteThrough = 1ULL << 3, // use write-through caching policy
-    CacheDisable = 1ULL << 4,
-    ExecuteDisable = 1ULL << 63, // disable instruction fetches
-};
+auto vmalloc(size_t size) -> void *;
 
-/**
- * @brief Allocate space for the new page table, and re-map essential mappings
- * mapped by Limine. Then free the old page table by reclaiming bootloader reclaimable
- * memory.
- */
-void vmm_init();
-
-/**
- * @brief Add a virtual to physical mapping to the tree.
- * Physical base should point to a contiguous region in physical memory of length
- * `length` whose frames have already been allocated.
- *
- * @param virtual_base
- * @param physical_base
- * @param length
- * @param flags permission and cache policy flags
- */
-void vmm_add_mapping(uintptr_t virtual_base,
-                     uintptr_t physical_base,
-                     uint64_t length,
-                     PageFlags flags);
+auto vfree(void *ptr) -> void;
 
 #endif

--- a/kernel/kernel/frame_allocator.cpp
+++ b/kernel/kernel/frame_allocator.cpp
@@ -93,18 +93,6 @@ bool is_allocatable(struct limine_memmap_entry *entry)
 }
 
 /**
- * @brief Print the base, limit, and mapping type of each of the initial Limine memory map
- */
-// void print_memory_map()
-// {
-//     for (size_t i = 0; i < limine::memory_map->entry_count; ++i)
-//     {
-//         struct limine_memmap_entry *entry = limine::memory_map->entries[i];
-//         DEBUG("base: %x, limit: %x, type: %x\n", entry->base, entry->length, entry->type);
-//     }
-// }
-
-/**
  * @brief Calculate the total number of allocatable frames for use in this system.
  */
 size_t get_num_allocatable_frames()
@@ -276,4 +264,30 @@ void free_limine_bootloader_memory()
 
     DEBUG("Reclaimed %d frames of Limine bootloader memory, %d available frames\n",
           reclaimed_frames, available_frames());
+}
+
+const char *limine_memmap_type(int type)
+{
+    switch (type)
+    {
+    case 0: return "USABLE";
+    case 1: return "RESERVED";
+    case 2: return "ACPI_RECLAIMABLE";
+    case 3: return "ACPI_NVS";
+    case 4: return "BAD_MEMORY";
+    case 5: return "BOOTLOADER_RECLAIMABLE";
+    case 6: return "KERNEL_AND_MODULES";
+    case 7: return "FRAMEBUFFER";
+    default: return "unknown";
+    }
+}
+
+void print_memory_map()
+{
+    for (size_t i = 0; i < limine::memory_map->entry_count; ++i)
+    {
+        struct limine_memmap_entry *entry = limine::memory_map->entries[i];
+        printf("base: %x, limit: %x, type: %s\n", entry->base, entry->length,
+            limine_memmap_type(entry->type));
+    }
 }

--- a/kernel/kernel/frame_allocator.cpp
+++ b/kernel/kernel/frame_allocator.cpp
@@ -13,6 +13,7 @@
 #include <stdio.h>
 
 #include <frg/optional.hpp>
+#include <kernel/constants.h>
 #include <kernel/frame_allocator.h>
 #include <kernel/kernel.h>
 #include <kernel/limine_features.h>
@@ -80,9 +81,6 @@ private:
 };
 
 frg::optional<FixedStack> free_stack;
-
-// The size of the physical frames in bytes
-constexpr size_t frame_size = 0x1000;
 
 /**
  * @brief Check if an entry in the Limine memory map is allocatable (available for use)

--- a/kernel/kernel/kernel.cpp
+++ b/kernel/kernel/kernel.cpp
@@ -8,6 +8,7 @@
 #include <kernel/kernel.h>
 #include <kernel/terminal.h>
 #include <kernel/types.h>
+#include <kernel/paging.h>
 #include <kernel/vmm.h>
 
 extern "C" void (*__init_array_start)(), (*__init_array_end)();
@@ -32,6 +33,7 @@ void kernel_init()
     idt_init();
     terminal_init();
     frame_allocator_init();
+    paging_init();
     vmm_init();
 }
 

--- a/kernel/kernel/main.cpp
+++ b/kernel/kernel/main.cpp
@@ -7,6 +7,8 @@
 #include <kernel/tests.h>
 #include <kernel/types.h> // LinkerAddress
 
+#include <kernel/frame_allocator.h>
+
 extern LinkerAddress kernel_stack_start;
 
 [[ noreturn ]]
@@ -19,6 +21,7 @@ void kernel_main()
     run_all_tests();
     
     printf("Hello, world!\n");
+    print_memory_map();
 
     kernel_hang();
 }

--- a/kernel/kernel/main.cpp
+++ b/kernel/kernel/main.cpp
@@ -21,7 +21,7 @@ void kernel_main()
     run_all_tests();
     
     printf("Hello, world!\n");
-    print_memory_map();
+    // print_memory_map();
 
     kernel_hang();
 }

--- a/kernel/kernel/paging.cpp
+++ b/kernel/kernel/paging.cpp
@@ -1,0 +1,220 @@
+/*
+limine page table maps kernel, framebuffer, and others (stack)
+allocate physical frame for PML4 table frame (page tree root)
+    convert physical address to virtual address mapped by Limine (is allocated frame guaranteed to be mapped?)
+    add essential mappings to new page table, allocating frames as needed for each depth
+
+*/
+
+// #include <dav/algorithm.hpp>
+#include <frg/optional.hpp>
+#include <kernel/constants.h>
+#include <kernel/paging.h>
+#include <kernel/frame_allocator.h>
+#include <kernel/PageTree.h>
+#include <kernel/kernel.h>
+#include <kernel/limine_features.h>
+#include <kernel/macros.h>
+#include <kernel/types.h>
+
+#include <string.h>
+#include <tuple>
+
+extern "C" void load_ptbr(uintptr_t page_table_physical_address);
+
+// virtual address locations of the readonly and read/write boundaries
+// of the kernel: specified by the linker
+extern LinkerAddress kernel_readonly_start,
+                     kernel_readonly_end,
+                     kernel_rw_start,
+                     kernel_rw_end;
+
+
+
+static frg::optional<PageTree> page_tree;
+
+struct Mapping {
+    MemoryRegion from_virtual {};
+    uintptr_t to_physical {};
+    PageFlags flags {};
+};
+
+static auto initial_mappings = frg::array<Mapping, 4> {{
+    {
+        // 4 GiB identity map
+        .from_virtual {0x1000, 0x100000000},
+        .to_physical {0x1000},
+        .flags {PageFlags::Write}
+    },
+    {
+        // 4 GiB HHDM map
+        .from_virtual {limine::hhdm_address->offset, 0x100000000}, 
+        .to_physical {0x0},
+        .flags {PageFlags::Write}
+    },
+    {
+        // kernel mapping (read-only section)
+        .from_virtual {reinterpret_cast<uintptr_t>(&kernel_readonly_start),
+            static_cast<size_t>(&kernel_readonly_end - &kernel_readonly_start)},
+        .to_physical {limine::kernel_address->physical_base},
+        .flags {PageFlags::None}
+    },
+    {
+        // kernel mapping (read/write section)
+        .from_virtual {reinterpret_cast<uintptr_t>(&kernel_rw_start),
+            static_cast<size_t>(&kernel_rw_end - &kernel_rw_start)},
+        .to_physical {limine::kernel_address->physical_base
+            + (&kernel_readonly_end - &kernel_readonly_start)},
+        .flags {PageFlags::Write}
+    }
+}};
+
+void add_initial_mappings()
+{
+    for (const auto &[from_virtual, to_physical, flags] : initial_mappings) {
+        paging_add_mapping(from_virtual.base, to_physical, from_virtual.size, flags);
+    }
+    DEBUG("Added initial mappings.\n");
+}
+
+void paging_init()
+{
+    /**
+     * The Limine boot protocol initializes the following mappings:
+     *  - identity map of the first 4 GiB starting at 0x1000
+     *  - A virtual address V above the HHDM address maps to HHDM - V
+     *      - the HHDM address is obtained through the Limine limine_hhdm feature
+     *  - an additional HHDM + identity mapping for any additional entry in the Limine memory map
+     *    (if not already covered by the first two mappings)
+     *      - the memory map can be accessed through the limine_memmap feature
+     *  - a mapping for the kernel, which can be obtained from the limine_kernel_address feature
+     *
+     * We create our own page table and fill it with the above mappings, then free the physical
+     * frames associated with Limine's page table (so that we can manage virtual memory ourselves).
+     *
+     * For the official documentation of the limine boot protocol, see
+     * https://github.com/limine-bootloader/limine/blob/v5.x-branch/PROTOCOL.md#entry-memory-layout
+     * 
+     */
+
+    DEBUG("Initializing virtual memory manager...\n");
+
+    // allocate memory for the root of the page tree
+    auto pml4_table_frame = allocate_frame();
+    DEBUG("Allocated PML4 table frame at (physical) %p\n", pml4_table_frame);
+
+    // since paging is already enabled, we need to access the physical frame
+    // by its virtual address
+    auto virtual_pml4_table_frame = kernel_physical_to_virtual(pml4_table_frame);
+
+    // construct the page tree, with space for the root node allocated
+    //  at the specified virtual address
+    page_tree.emplace(virtual_pml4_table_frame);
+    DEBUG("Constructed page tree at (virtual) %p\n", virtual_pml4_table_frame);
+    
+    
+    add_initial_mappings();
+
+    // load page table base register (PTBR) to point to the physical address of the page table
+    load_ptbr(reinterpret_cast<uintptr_t>(pml4_table_frame));
+    DEBUG("Loaded PTBR to point to %p\n", pml4_table_frame);
+
+    free_limine_bootloader_memory();
+}
+
+/**
+ * @brief Round the address down to the nearest page.
+ */
+uint64_t page_floor(uint64_t address)
+{
+    return address - (address % page_size);
+}
+
+/**
+ * @brief Round the address up to the nearest page,
+ * or down if the nearest page would cause an overflow.
+ */
+uint64_t page_ceil(uint64_t address)
+{
+    if (address % page_size == 0)
+        return address;
+    // check for overflow
+    // TODO: better more portable way to do this? relies on uint64_t
+    if (UINT64_MAX - page_size < address)
+        return address;
+    return page_floor(address + page_size);
+}
+
+struct PageRange {
+    uintptr_t first_page = 0;
+    uintptr_t last_page = 0;
+};
+
+auto get_page_range(uintptr_t virtual_base, size_t length) -> PageRange
+{
+    const auto first_page = page_floor(virtual_base);
+    const auto last_page = [&] {
+        // check for overflow
+        if (page_floor(UINT64_MAX) - length < virtual_base)
+            return page_floor(UINT64_MAX);
+        return page_ceil(virtual_base + length);
+    }();
+    return PageRange {first_page, last_page};
+}
+
+void paging_add_mapping(uintptr_t virtual_base,
+                     uintptr_t physical_base,
+                     uint64_t length,
+                     PageFlags flags)
+{
+    // addresss of the first and last page containing the virtual memory region
+    const auto [first_page, last_page] = get_page_range(virtual_base, length);
+    // address of the first and last frames containing the virtual memory region 
+    uint64_t first_frame = page_floor(physical_base);
+    for (uint64_t page = first_page, frame = first_frame;
+         page < last_page;
+         page += page_size, frame += frame_size) 
+    {
+        page_tree->map_page_to_frame(page, frame, flags);
+    }
+
+    uint64_t num_pages = (last_page - first_page) / page_size;
+    DEBUG("Mapped %d virtual page(s) %x to %x (end-exclusive) to %d "
+          "physical frame(s) starting at %x. %d physical frames left.\n",
+          num_pages, first_page, last_page, num_pages, first_frame, available_frames());
+}
+
+auto paging_allocate_and_map(uintptr_t virtual_base, size_t length, PageFlags flags) -> void
+{
+    const auto [first_page, last_page] = get_page_range(virtual_base, length);
+    for (auto page = first_page; page != last_page; page += page_size) {
+        paging_add_mapping(page, reinterpret_cast<uintptr_t>(allocate_frame()), page_size, flags);
+    }
+}
+
+auto paging_get_initial_free_regions() -> frg::array<MemoryRegion, 16> {
+    auto used_mappings = initial_mappings;
+    // dav::static_sort(begin(used_mappings), end(used_mappings),
+    //     [](const auto &lhs, const auto &rhs) {
+    //         return dav::tie(lhs.from_virtual.base, lhs.from_virtual.size, lhs.to_physical)
+    //             < dav::tie(rhs.from_virtual.base, rhs.from_virtual.size, lhs.from_physical);
+    //     });
+    
+    auto free_regions = frg::array<MemoryRegion, 16> {};
+    auto i = std::size_t {0};
+    auto base = uintptr_t {0x1000};
+    for (const auto &[from_virtual, to_physical, flags]: used_mappings) {
+        const auto mapping_start = from_virtual.base;
+        const auto mapping_end = mapping_start + from_virtual.size;
+        if (base >= mapping_start) {
+            base = std::max(base, mapping_end);
+        } else {
+            if (i > free_regions.size()) {
+                kernel_panic("exceeded number of supported free regions (16)\n");
+            }
+            free_regions[i++] = {base, from_virtual.base - base};
+            base = mapping_end;
+        }
+    }
+    return free_regions;
+}

--- a/kernel/kernel/vmm.cpp
+++ b/kernel/kernel/vmm.cpp
@@ -1,157 +1,35 @@
-/*
-limine page table maps kernel, framebuffer, and others (stack)
-allocate physical frame for PML4 table frame (page tree root)
-    convert physical address to virtual address mapped by Limine (is allocated frame guaranteed to be mapped?)
-    add essential mappings to new page table, allocating frames as needed for each depth
-
-*/
-
 #include <frg/optional.hpp>
-#include <kernel/vmm.h>
-#include <kernel/frame_allocator.h>
-#include <kernel/PageTree.h>
+#include <kernel/FreeListAllocator.h>
 #include <kernel/kernel.h>
-#include <kernel/limine_features.h>
 #include <kernel/macros.h>
-#include <kernel/types.h>
+#include <kernel/paging.h>
+#include <kernel/vmm.h>
 
-#include <string.h>
+using allocated_type = std::byte;
+using virtual_allocator_type = FreeListAllocator<allocated_type>;
 
-extern "C" void load_ptbr(uintptr_t page_table_physical_address);
+static auto allocator = virtual_allocator_type {};
 
-#define PAGE_SIZE 0x1000
-#define FRAME_SIZE 0x1000
-
-// virtual address locations of the readonly and read/write boundaries
-// of the kernel: specified by the linker
-extern LinkerAddress kernel_readonly_start,
-                     kernel_readonly_end,
-                     kernel_rw_start,
-                     kernel_rw_end;
-
-frg::optional<PageTree> page_tree;
-
-void add_initial_mappings()
-{
-    // add initial 4 GiB identity map
-    vmm_add_mapping(0x1000, 0x1000, 0x100000000, PageFlags::Write);
-
-    // add 4 GiB HHDM map
-    vmm_add_mapping(limine::hhdm_address->offset, 0x0, 0x100000000, PageFlags::Write);
-
-    // add kernel mapping (readonly section)
-    uint64_t kernel_readonly_length = &kernel_readonly_end - &kernel_readonly_start;
-    uintptr_t kernel_readonly_start_physical = limine::kernel_address->physical_base;
-    vmm_add_mapping(reinterpret_cast<uintptr_t>(&kernel_readonly_start),
-                    kernel_readonly_start_physical,
-                    kernel_readonly_length,
-                    PageFlags::None);
-    DEBUG("Mapped read-only kernel section.\n");
-
-    // add kernel mapping (read/write section)
-    uint64_t kernel_rw_length = &kernel_rw_end - &kernel_rw_start;
-    uintptr_t kernel_rw_start_physical = kernel_readonly_start_physical + kernel_readonly_length;
-    vmm_add_mapping(reinterpret_cast<uintptr_t>(&kernel_rw_start),
-                    kernel_rw_start_physical,
-                    kernel_rw_length,
-                    PageFlags::Write);
-    DEBUG("Mapped read/write kernel section.\n");
-}
-
-void vmm_init()
-{
-    /**
-     * The Limine boot protocol initializes the following mappings:
-     *  - identity map of the first 4 GiB starting at 0x1000
-     *  - A virtual address V above the HHDM address maps to HHDM - V
-     *      - the HHDM address is obtained through the Limine limine_hhdm feature
-     *  - an additional HHDM + identity mapping for any additional entry in the Limine memory map
-     *    (if not already covered by the first two mappings)
-     *      - the memory map can be accessed through the limine_memmap feature
-     *  - a mapping for the kernel, which can be obtained from the limine_kernel_address feature
-     *
-     * We create our own page table and fill it with the above mappings, then free the physical
-     * frames associated with Limine's page table (so that we can manage virtual memory ourselves).
-     *
-     * For the official documentation of the limine boot protocol, see
-     * https://github.com/limine-bootloader/limine/blob/v5.x-branch/PROTOCOL.md#entry-memory-layout
-     * 
-     */
-
-    DEBUG("Initializing virtual memory manager...\n");
-
-    // allocate memory for the root of the page tree
-    auto pml4_table_frame = allocate_frame();
-    DEBUG("Allocated PML4 table frame at (physical) %p\n", pml4_table_frame);
-
-    // since paging is already enabled, we need to access the physical frame
-    // by its virtual address
-    auto virtual_pml4_table_frame = kernel_physical_to_virtual(pml4_table_frame);
-
-    // construct the page tree, with space for the root node allocated
-    //  at the specified virtual address
-    page_tree.emplace(virtual_pml4_table_frame);
-    DEBUG("Constructed page tree at (virtual) %p\n", virtual_pml4_table_frame);
-    
-    
-    add_initial_mappings();
-    char *before_page_table = reinterpret_cast<char *>(pml4_table_frame) - 20;
-    memcpy(before_page_table, "david tran", 13);
-    DEBUG("Added initial mappings.\n");
-
-    // load page table base register (PTBR) to point to the physical address of the page table
-    load_ptbr(reinterpret_cast<uintptr_t>(pml4_table_frame));
-    DEBUG("Loaded PTBR to point to %p\n", pml4_table_frame);
-
-    free_limine_bootloader_memory();
-}
-
-/**
- * @brief Round the address down to the nearest page.
- */
-uint64_t page_floor(uint64_t address)
-{
-    return address - (address % PAGE_SIZE);
-}
-
-/**
- * @brief Round the address up to the nearest page,
- * or down if the nearest page would cause an overflow.
- */
-uint64_t page_ceil(uint64_t address)
-{
-    if (address % PAGE_SIZE == 0)
-        return address;
-    // check for overflow
-    if (UINT64_MAX - PAGE_SIZE < address)
-        return address;
-    return page_floor(address + PAGE_SIZE);
-}
-
-void vmm_add_mapping(uintptr_t virtual_base,
-                     uintptr_t physical_base,
-                     uint64_t length,
-                     PageFlags flags)
-{
-    // addresss of the first and last page containing the virtual memory region
-    const uint64_t first_page = page_floor(virtual_base);
-    const uint64_t last_page = [&]{
-        // check for overflow
-        if (page_floor(UINT64_MAX) - length < virtual_base)
-            return page_floor(UINT64_MAX);
-        return page_ceil(virtual_base + length);
-    }();
-    // address of the first and last frames containing the virtual memory region 
-    uint64_t first_frame = page_floor(physical_base);
-    for (uint64_t page = first_page, frame = first_frame;
-         page < last_page;
-         page += PAGE_SIZE, frame += FRAME_SIZE)
-    {
-        page_tree->map_page_to_frame(page, frame, flags);
+auto vmm_init() -> void {
+    const auto free_virtual_memory_regions = paging_get_initial_free_regions();
+    for (const auto &[base, size] : free_virtual_memory_regions) {
+        if (size == 0) {
+            continue;
+        }
+        add_virtual_memory(reinterpret_cast<void *>(base), size);
+        DEBUG("Initialized VMM with region at %x with size %x\n", base, size);
     }
+    DEBUG("Initialized VMM.\n");
+}
 
-    uint64_t num_pages = (last_page - first_page) / PAGE_SIZE;
-    DEBUG("Mapped %d virtual page(s) %x to %x (end-exclusive) to %d "
-          "physical frame(s) starting at %x. %d physical frames left.\n",
-          num_pages, first_page, last_page, num_pages, first_frame, available_frames());
+auto add_virtual_memory(void *base, size_t size) -> void {
+    allocator.add_memory_impl(reinterpret_cast<allocated_type *>(base), size);
+}
+
+auto vmalloc(size_t size) -> void * {
+    return allocator.allocate_impl(size);
+}
+
+auto vfree(void *ptr) -> void {
+    allocator.deallocate_impl(reinterpret_cast<allocated_type *>(ptr), 0);
 }

--- a/kernel/kernel/vmm.cpp
+++ b/kernel/kernel/vmm.cpp
@@ -31,22 +31,6 @@ extern LinkerAddress kernel_readonly_start,
 
 frg::optional<PageTree> page_tree;
 
-const char *limine_memmap_type(int type)
-{
-    switch (type)
-    {
-    case 0: return "USABLE";
-    case 1: return "RESERVED";
-    case 2: return "ACPI_RECLAIMABLE";
-    case 3: return "ACPI_NVS";
-    case 4: return "BAD_MEMORY";
-    case 5: return "BOOTLOADER_RECLAIMABLE";
-    case 6: return "KERNEL_AND_MODULES";
-    case 7: return "FRAMEBUFFER";
-    default: return "unknown";
-    }
-}
-
 void add_initial_mappings()
 {
     // add initial 4 GiB identity map

--- a/kernel/lib/3rdparty/davSTL/LICENSE
+++ b/kernel/lib/3rdparty/davSTL/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 David Tran
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/kernel/lib/3rdparty/davSTL/include/dav/algorithm.hpp
+++ b/kernel/lib/3rdparty/davSTL/include/dav/algorithm.hpp
@@ -1,0 +1,39 @@
+#ifndef DAVSTL_ALGORITHM_HPP
+#define DAVSTL_ALGORITHM_HPP
+
+#include <iterator>
+
+namespace dav {
+
+/**
+ * @brief Sort a container in-place, without heap-allocations.
+ * 
+ * Quick sort.
+ */
+template <typename Iter, typename Cmp>
+auto static_sort(Iter begin, Iter end, Cmp cmp) -> void {
+    auto partition = [](Iter begin, Iter end, Cmp cmp) {
+        auto pivot = std::prev(end);
+        auto i = begin;
+        while (auto j = begin; j != pivot; ++j) {
+            if (cmp(*j, *pivot)) {
+                std::iter_swap(i, j);
+                ++i;
+            }
+        }
+        std::iter_swap(i, pivot);
+        return i;
+    };
+
+    if (std::distance(begin, end) <= 1) {
+        return;
+    }
+
+    auto pivot = partition(begin, end, cmp);
+    static_sort(begin, pivot, cmp);
+    static_sort(std::next(pivot), end, cmp);
+}
+
+}
+
+#endif // DAVSTL_ALGORITHM_HPP

--- a/kernel/lib/3rdparty/module.mk
+++ b/kernel/lib/3rdparty/module.mk
@@ -1,3 +1,6 @@
 DIR := kernel/lib/3rdparty
 
-INCLUDE_DIRS += $(DIR)/frigg/include $(DIR)/cxxshim/stage2/include
+INCLUDE_DIRS += \
+	$(DIR)/frigg/include \
+	$(DIR)/cxxshim/stage2/include \
+	$(DIR)/davSTL/include

--- a/kernel/module.mk
+++ b/kernel/module.mk
@@ -12,6 +12,7 @@ OBJS += $(addprefix $(DIR)/, \
 	kernel/limine_features.o \
 	kernel/load_ptbr.o \
 	kernel/main.o \
+	kernel/paging.o \
 	kernel/PageTree.o \
 	kernel/PageTreeNode.o \
 	kernel/reload_segment_registers.o \


### PR DESCRIPTION
The interface for the VMM is defined in vmm.h (what used to be in vmm.h is now moved to paging.h).

A compile-time (CRTP) interface is defined in Allocator.h: the implementation used for the VMM is in FreeListAllocator.h.

On-demand paging is implemented through the page-fault interrupt service routine: upon a page-fault, the system allocates one page for the faulting address and maps it in the page table.

Tests are added in `tests.cpp:test_free_list_allocator()` although it is certainly not complete. The allocator supports coalescing.